### PR TITLE
scala.concurrent.Future support with typeclasses expanded greatly.

### DIFF
--- a/scala210/main/scala/std/Future.scala
+++ b/scala210/main/scala/std/Future.scala
@@ -1,21 +1,52 @@
 package scalaz.contrib
 package std
 
-import scalaz.Monad
+import scalaz._
 
 import scala.concurrent.{Future, ExecutionContext, CanAwait, Await}
 import scala.concurrent.duration.Duration
 
 trait FutureInstances {
-
-  implicit def futureInstance(implicit ec: ExecutionContext): Monad[Future] = new Monad[Future] {
+  implicit def futureInstance(implicit executionContext: ExecutionContext): Monad[Future] with Cobind[Future] with Cojoin[Future] with Each[Future] = 
+    new Monad[Future] with Cobind[Future] with Cojoin[Future] with Each[Future] {
     def point[A](a: => A): Future[A] = Future(a)
     def bind[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa flatMap f
     override def map[A, B](fa: Future[A])(f: A => B): Future[B] = fa map f
+    def cobind[A, B](fa: Future[A])(f: Future[A] => B): Future[B] = Future(f(fa))
+    def cojoin[A](a: Future[A]): Future[Future[A]] = Future(a)
+    def each[A](fa: Future[A])(f: A => Unit) = fa foreach f
   }
 
+  /**
+   * Requires explicit usage as the use of Await.result can throw an exception, which is inherently bad.
+   */
+  def futureCopointed(duration: Duration)(implicit executionContext: ExecutionContext): Copointed[Future] = new Copointed[Future] {
+    def map[A, B](fa: Future[A])(f: A => B): Future[B] = fa map f
+    def copoint[A](f: Future[A]): A = Await.result(f, duration)
+  }
+
+  implicit def futureComonad(implicit cb: Cobind[Future], cj: Cojoin[Future], cp: Copointed[Future]): Comonad[Future] = new Comonad[Future] {
+    def map[A, B](fa: Future[A])(f: A => B): Future[B] = cp.map(fa)(f)
+    def cobind[A, B](fa: Future[A])(f: Future[A] => B): Future[B] = cb.cobind(fa)(f)
+    def cojoin[A](a: Future[A]): Future[Future[A]] = cj.cojoin(a)
+    def copoint[A](f: Future[A]): A = cp.copoint(f)
+  }
+
+  implicit def futureMonoid[A](implicit m: Monoid[A], executionContext: ExecutionContext): Monoid[Future[A]] = new Monoid[Future[A]] {
+    def zero: Future[A] = Future(m.zero)
+    def append(f1: Future[A], f2: => Future[A]): Future[A] = for {
+      first <- f1
+      second <- f2
+    } yield m.append(first, second)
+  }
+
+  implicit def futureGroup[A](implicit g: Group[A], m: Monoid[Future[A]], executionContext: ExecutionContext): Group[Future[A]] = new Group[Future[A]] {
+    def zero: Future[A] = m.zero
+    def inverse(f: Future[A]): Future[A] = f.map(value => g.inverse(value))
+    def append(f1: Future[A], f2: => Future[A]): Future[A] = m.append(f1, f2)
+  }
 }
 
-object future extends FutureInstances
+object ScalazFuture extends FutureInstances
 
 // vim: expandtab:ts=2:sw=2

--- a/scala210/test/scala/FutureTest.scala
+++ b/scala210/test/scala/FutureTest.scala
@@ -3,29 +3,37 @@ package scalaz.contrib
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 
-import scalaz.{Equal, Spec}
+import scalaz._
 import scalaz.syntax.functor._
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
 import scalaz.scalacheck.ScalaCheckBinding._
 import scalaz.std.AllInstances._
+import scalaz.Tags._
 
 import scala.concurrent._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class FutureTest extends Spec {
+  import scalaz.contrib.std.ScalazFuture._
 
-  import scalaz.contrib.std.future._
-
-  implicit val duration: Duration = 1.seconds
+  val duration: Duration = 1.seconds
 
   implicit def futureEqual[A : Equal] = Equal[A] contramap { future: Future[A] => Await.result(future, duration) }
 
   implicit def FutureArbitrary[A](implicit a: Arbitrary[A]): Arbitrary[Future[A]] = implicitly[Arbitrary[A]] map { x => Future(x) }
 
   checkAll(monad.laws[Future])
+  checkAll(monoid.laws[Future[Int @@ Multiplication]])
+  checkAll(group.laws[Future[Int]])
 
+  // Scope these away from the rest as Copointed[Future] is a little evil.
+  // Should fail to compile by default: implicitly[Copointed[Future]]
+  {
+    implicit val copointedFuture: Copointed[Future] = futureCopointed(duration)
+    checkAll(comonad.laws[Future])
+  }
 }
 
 // vim: expandtab:ts=2:sw=2


### PR DESCRIPTION
Lots more of the typeclasses, only main difference is that the object that extends FutureInstances is now called ScalazFuture, mostly because there's a method called "future" in the scalaz.concurrent package, which the original named collided with.
