### PR TITLE
Added "checkThen" function to Checker to allow a fail-fast behaviour

### DIFF
--- a/validation-ext/test/scala/CheckerSpec.scala
+++ b/validation-ext/test/scala/CheckerSpec.scala
@@ -2,7 +2,7 @@ package scalaz.contrib
 
 import org.specs2.mutable.Specification
 import scalaz.contrib.validator.string._
-import scalaz.NonEmptyList
+import scalaz.{Failure, NonEmptyList}
 
 class CheckerSpec extends Specification {
 
@@ -12,12 +12,13 @@ class CheckerSpec extends Specification {
 
     "execute more validators when it's not failed yet" in {
       c.checkThat(strLength(6, "not 6"))
-        .checkThen(strLength(99, "not 99")) mustEqual YesChecker(s, Vector("not 99"))
+        .checkThen(strLength(99, "not 99"))
+        .checkThen(strLength(100, "not 100")).toValidation mustEqual Failure(NonEmptyList("not 99"))
     }
 
-    "not execute any more validators when it's already failed" in {
+    "execute no more validators when it's already failed" in {
       c.checkThat(strLength(100, "not 100"))
-        .checkThen(strLength(99, "not 99")) mustEqual NoChecker(NonEmptyList("not 100"))
+        .checkThen(strLength(99, "not 99")).toValidation mustEqual Failure(NonEmptyList("not 100"))
     }
   }
 }

--- a/validation-ext/test/scala/CheckerSpec.scala
+++ b/validation-ext/test/scala/CheckerSpec.scala
@@ -2,7 +2,7 @@ package scalaz.contrib
 
 import org.specs2.mutable.Specification
 import scalaz.contrib.validator.string._
-import scalaz.{Failure, NonEmptyList}
+import scalaz.{Success, Failure, NonEmptyList}
 
 class CheckerSpec extends Specification {
 
@@ -19,6 +19,12 @@ class CheckerSpec extends Specification {
     "execute no more validators when it's already failed" in {
       c.checkThat(strLength(100, "not 100"))
         .checkThen(strLength(99, "not 99")).toValidation mustEqual Failure(NonEmptyList("not 100"))
+    }
+
+    "successful validation" in {
+      c.checkThat(strLength(6, "not 6"))
+        .checkThen(minStrLength(1, "min 1"))
+        .checkThen(maxStrLength(6, "max 7")).toValidation mustEqual Success("MyTest")
     }
   }
 }

--- a/validation-ext/test/scala/CheckerSpec.scala
+++ b/validation-ext/test/scala/CheckerSpec.scala
@@ -1,0 +1,23 @@
+package scalaz.contrib
+
+import org.specs2.mutable.Specification
+import scalaz.contrib.validator.string._
+import scalaz.NonEmptyList
+
+class CheckerSpec extends Specification {
+
+  "Checker checkThen" should {
+    val s = "MyTest"
+    val c = Checker.check(s)
+
+    "execute more validators when it's not failed yet" in {
+      c.checkThat(strLength(6, "not 6"))
+        .checkThen(strLength(99, "not 99")) mustEqual YesChecker(s, Vector("not 99"))
+    }
+
+    "not execute any more validators when it's already failed" in {
+      c.checkThat(strLength(100, "not 100"))
+        .checkThen(strLength(99, "not 99")) mustEqual NoChecker(NonEmptyList("not 100"))
+    }
+  }
+}


### PR DESCRIPTION
Sometimes you don't want to execute following validators when a preceding one fails. The checkThen function allows this now.
