### PR TITLE
Add a semigroup instance for Interval defined as "intersection".

### DIFF
--- a/nscala-time/main/scala/instances.scala
+++ b/nscala-time/main/scala/instances.scala
@@ -65,7 +65,10 @@ trait Instances {
     val zero = Seconds.ZERO
   }
 
-  implicit val intervalInstance = Equal.equalA[Interval]
+  implicit val intervalInstance = new Semigroup[Interval] with Equal[Interval] {
+    def append(x: Interval, y: => Interval) = Option(x overlap y) getOrElse new Interval(0, 0)
+    def equal(x: Interval, y: Interval) = x == y
+  }
 
   implicit val yearMonthInstance     = orderFromInt[YearMonth](_ compareTo _)
   implicit val monthDayInstance      = orderFromInt[MonthDay](_ compareTo _)

--- a/nscala-time/test/scala/NScalaTimeTest.scala
+++ b/nscala-time/test/scala/NScalaTimeTest.scala
@@ -24,6 +24,7 @@ class NScalaTimeTest extends Spec {
   
   checkAll("Instant", order.laws[Instant])
   
+  checkAll("Interval", semigroup.laws[Interval])
   checkAll("Interval", equal.laws[Interval])
 
   checkAll("LocalDate", enum.laws[LocalDate])

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.1
+sbt.version=0.13.5

--- a/project/build.scala
+++ b/project/build.scala
@@ -165,7 +165,7 @@ object ScalazContribBuild extends Build {
     settings = standardSettings ++ Seq(
       name := "scalaz-nscala-time",
       libraryDependencies ++= Seq(
-        "com.github.nscala-time" %% "nscala-time" % "1.0.0",
+        "com.github.nscala-time" %% "nscala-time" % "1.2.0",
         scalazSpecs2,
         scalazScalacheck
       )


### PR DESCRIPTION
I think of this like the product of a Ring, with an annihilating zero, but there's no "union" operator for Intervals in Joda-time.
overlap is defined here:
http://joda-time.sourceforge.net/apidocs/org/joda/time/Interval.html#overlap(org.joda.time.ReadableInterval)
Says it returns null on no overlap, but that throws a NPE in the scalacheck properties. So instead I return an interval that starts and stops at dawn of epoch to serve as the "empty set".
