### PR TITLE
Depend on joda-time directly instead of nscala-time

### DIFF
--- a/nscala-time/main/scala/ShowInstances.scala
+++ b/nscala-time/main/scala/ShowInstances.scala
@@ -1,0 +1,36 @@
+package scalaz.contrib
+package nscala_time
+
+import org.joda.time._
+
+import scalaz.Show
+
+/**
+ * Created by tstevens on 5/3/15.
+ */
+trait ShowInstances {
+
+  implicit val showDuration: Show[Duration] = Show.showFromToString
+
+  implicit val showPeriod: Show[Period] = Show.showFromToString
+
+  implicit val showYears: Show[Years] = Show.showFromToString
+
+  implicit val showMonths: Show[Months] = Show.showFromToString
+
+  implicit val showDays: Show[Days] = Show.showFromToString
+
+  implicit val showHours: Show[Hours] = Show.showFromToString
+
+  implicit val showMinutes: Show[Minutes] = Show.showFromToString
+
+  implicit val showSeconds: Show[Seconds] = Show.showFromToString
+
+  implicit val showInterval: Show[Interval] = Show.showFromToString
+
+  implicit val showDateTime: Show[DateTime] = Show.showFromToString
+
+  implicit val showLocalDate: Show[LocalDate] = Show.showFromToString
+
+  implicit val showLocalDateTime: Show[LocalDateTime] = Show.showFromToString
+}

--- a/nscala-time/main/scala/instances.scala
+++ b/nscala-time/main/scala/instances.scala
@@ -19,7 +19,7 @@ trait Instances {
 
   implicit val periodInstance = new Monoid[Period] with Equal[Period] {
     override val zero = Period.ZERO
-    override def append(f1: Period, f2: ⇒ Period) = new com.github.nscala_time.time.RichPeriod(f1) + f2
+    override def append(f1: Period, f2: ⇒ Period) = f1 plus f2
     override def equal(a1: Period, a2: Period) = a1 == a2
   }
 

--- a/nscala-time/main/scala/package.scala
+++ b/nscala-time/main/scala/package.scala
@@ -1,4 +1,4 @@
 package scalaz.contrib
 
 package object nscala_time
-  extends Instances
+  extends Instances with ShowInstances

--- a/project/build.scala
+++ b/project/build.scala
@@ -147,7 +147,7 @@ object ScalazContribBuild extends Build {
     id = "nscala_time",
     base = file("nscala-time"),
     settings = standardSettings ++ Seq(
-      name := "scalaz-nscala-time",
+      name := "scalaz-nscala-time-gcsi",
       libraryDependencies ++= Seq(
         "joda-time" % "joda-time" % "2.+",
         scalazSpecs2,

--- a/project/build.scala
+++ b/project/build.scala
@@ -149,7 +149,7 @@ object ScalazContribBuild extends Build {
     settings = standardSettings ++ Seq(
       name := "scalaz-nscala-time",
       libraryDependencies ++= Seq(
-        "com.github.nscala-time" %% "nscala-time" % "1.2.0",
+        "joda-time" % "joda-time" % "2.+",
         scalazSpecs2,
         scalazScalacheck
       )

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-version in ThisBuild := "0.3-SNAPSHOT"
+version in ThisBuild := "0.3"


### PR DESCRIPTION
nscala-time should depend on joda time instead of nscala because

nscala is a wrapper around joda time
there is only one code statement in nscala-time that relies on nscala which can be replaced with a joda level library statement
some people use joda in scala who do not use nscala
